### PR TITLE
Add major version folder structure to release notes

### DIFF
--- a/docs/ReleaseNotes/Version 26/26.2.202507.md
+++ b/docs/ReleaseNotes/Version 26/26.2.202507.md
@@ -1,6 +1,6 @@
 ---
 Title: "26.2.202507"
-parent: "Release Notes"
+parent: "Version 26"
 ---
 
 # Dysel BC 26.2.202507

--- a/docs/ReleaseNotes/Version 26/26.3.202508.md
+++ b/docs/ReleaseNotes/Version 26/26.3.202508.md
@@ -1,6 +1,6 @@
 ---
 Title: "26.3.202508"
-parent: "Release Notes"
+parent: "Version 26"
 ---
 
 # Dysel BC 26.3.202508

--- a/docs/ReleaseNotes/Version 26/26.4.202509.md
+++ b/docs/ReleaseNotes/Version 26/26.4.202509.md
@@ -1,6 +1,6 @@
 ---
 Title: "26.4.202509"
-parent: "Release Notes"
+parent: "Version 26"
 ---
 
 # Dysel BC 26.4.202509

--- a/docs/ReleaseNotes/Version 26/26.5.202510.md
+++ b/docs/ReleaseNotes/Version 26/26.5.202510.md
@@ -1,6 +1,6 @@
 ---
 Title: "26.5.202510"
-parent: "Release Notes"
+parent: "Version 26"
 ---
 
 # Dysel BC 26.5.202510

--- a/docs/ReleaseNotes/Version 26/26.6.202511.md
+++ b/docs/ReleaseNotes/Version 26/26.6.202511.md
@@ -1,6 +1,6 @@
 ---
 Title: "26.6.202511"
-parent: "Release Notes"
+parent: "Version 26"
 ---
 
 # Dysel BC 26.6.202511

--- a/docs/ReleaseNotes/Version 26/index.md
+++ b/docs/ReleaseNotes/Version 26/index.md
@@ -1,0 +1,10 @@
+---
+title: "Version 26"
+parent: "Release Notes"
+---
+
+# Version 26 (BC 2025 Release Wave 1)
+
+This section contains the release notes for the Dysel BC apps for **version 26**, which aligns with **Microsoft Dynamics 365 Business Central 2025 Release Wave 1**.
+
+Each release note page covers the changes shipped in that monthly update, including new features, improvements, and bug fixes.

--- a/docs/ReleaseNotes/Version 27/27.1.202512.md
+++ b/docs/ReleaseNotes/Version 27/27.1.202512.md
@@ -1,6 +1,6 @@
 ---
 Title: "27.1.202512"
-parent: "Release Notes"
+parent: "Version 27"
 ---
 
 # Dysel BC 27.1.202512

--- a/docs/ReleaseNotes/Version 27/27.2.202601.md
+++ b/docs/ReleaseNotes/Version 27/27.2.202601.md
@@ -1,6 +1,6 @@
 ---
 Title: "27.2.202601"
-parent: "Release Notes"
+parent: "Version 27"
 ---
 
 # Dysel BC 27.2.202601

--- a/docs/ReleaseNotes/Version 27/27.3.202602.md
+++ b/docs/ReleaseNotes/Version 27/27.3.202602.md
@@ -1,6 +1,6 @@
 ---
 Title: "27.3.202602"
-parent: "Release Notes"
+parent: "Version 27"
 ---
 
 # Dysel BC 27.3.202602

--- a/docs/ReleaseNotes/Version 27/27.4.202603.md
+++ b/docs/ReleaseNotes/Version 27/27.4.202603.md
@@ -1,6 +1,6 @@
 ---
 Title: "27.4.202603"
-parent: "Release Notes"
+parent: "Version 27"
 ---
 
 # Dysel BC 27.4.202603

--- a/docs/ReleaseNotes/Version 27/27.5.202604.md
+++ b/docs/ReleaseNotes/Version 27/27.5.202604.md
@@ -1,6 +1,6 @@
 ---
 Title: "27.5.202604"
-parent: "Release Notes"
+parent: "Version 27"
 ---
 
 # Dysel BC 27.5.202604

--- a/docs/ReleaseNotes/Version 27/index.md
+++ b/docs/ReleaseNotes/Version 27/index.md
@@ -1,0 +1,10 @@
+---
+title: "Version 27"
+parent: "Release Notes"
+---
+
+# Version 27 (BC 2025 Release Wave 2)
+
+This section contains the release notes for the Dysel BC apps for **version 27**, which aligns with **Microsoft Dynamics 365 Business Central 2025 Release Wave 2**.
+
+Each release note page covers the changes shipped in that monthly update, including new features, improvements, and bug fixes.


### PR DESCRIPTION
Closes #49

## Summary

Restructures the release notes section by grouping documents under versioned subfolders (`Version 26` and `Version 27`) instead of a single flat folder.

### Changes

- Moved all Version 26 release notes (`26.2` – `26.6`) into `ReleaseNotes/Version 26/`
- Moved all Version 27 release notes (`27.1` – `27.5`) into `ReleaseNotes/Version 27/`
- Added `index.md` for each version folder, describing the version and its corresponding BC release wave
- Updated the `parent` frontmatter in each release note from `"Release Notes"` to the title of their version index (`"Version 26"` / `"Version 27"`)